### PR TITLE
SBCL and quicklisp version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM davazp/quicksbcl
+FROM lokedhs/sbcl-quicklisp
 
 ENV LC_TYPE=en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM lokedhs/sbcl-quicklisp
 
 ENV LC_TYPE=en_US.UTF-8
 
-RUN apt-get update; apt-get upgrade -y; apt-get install -y openssl;
+RUN apt-get update; apt-get upgrade -y; apt-get install -y openssl; apt-get install -y libssl1.0.0;
 
 ADD ./.utf8-sbclrc /root/.utf8-sbclrc
 


### PR DESCRIPTION
Issue #1 indicated that the version of SBCL and QuickLisp is fairly
old, leading to incompatibilities with modern slime versions.  This
update attempts to tackle this issue by basing ourselves on more
modern SBCL and QuickLisp versions.

The base images for SBCL and QuickLisp are fairly new.  It is to be
seen whether or not these images are updated regularly or if we need
to set up infrastructure for this oursleves.  This PR bases itself on
an image with a Dockerfile so it should be fairly straightforward to
update it in the future.